### PR TITLE
add GH workflow for nginx as template

### DIFF
--- a/.github/workflows/push-nginx.yaml
+++ b/.github/workflows/push-nginx.yaml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+        branches:
+            - "**"
+        paths:
+          - 'nginx/ssl-termination/**'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ECR_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Login to ECR
+        run: ci/scripts/login-to-ecr.sh
+
+      - name: Build and push
+        env:
+          DOCKERFILE_PATH: nginx/ssl-termination
+          IMAGE_NAME: nginx-ssl-termination
+        run: ci/scripts/build-and-push.sh


### PR DESCRIPTION
This pull request includes a significant change to the `.github/workflows/push-nginx.yaml` file. The change introduces a new GitHub Actions workflow named "Build and Push Docker Images". This workflow is triggered on any push to the repository that affects files in the 'nginx/ssl-termination' directory. The workflow includes several steps, such as checking out the code, configuring AWS credentials, logging in to ECR, and building and pushing Docker images.

Key changes:

* [`.github/workflows/push-nginx.yaml`](diffhunk://#diff-0a145a4168058fa0a8aed6852219af3f2e6db2e6016380e1db3a3f727cb2df36R1-R30): Introduced a new GitHub Actions workflow named "Build and Push Docker Images". This workflow is triggered on any push to the repository that affects files in the 'nginx/ssl-termination' directory. The workflow includes steps for checking out the code, configuring AWS credentials, logging in to ECR, and building and pushing Docker images.