### PR TITLE
set Host header when proxying

### DIFF
--- a/nginx/ssl-termination/nginx.conf
+++ b/nginx/ssl-termination/nginx.conf
@@ -8,6 +8,7 @@ http {
 
         location / {
             proxy_pass       http://127.0.0.1:2300;
+            proxy_set_header Host $host;
             port_in_redirect off;
         }
     }


### PR DESCRIPTION
This should make nginx as transparent as we need