### PR TITLE
Increase nginx proxy buffer size

### DIFF
--- a/nginx/ssl-termination/nginx.conf
+++ b/nginx/ssl-termination/nginx.conf
@@ -10,6 +10,11 @@ http {
             proxy_pass       http://127.0.0.1:2300;
             proxy_set_header Host $host;
             port_in_redirect off;
+
+            # Upstream can write larger response headers than nginx's extremely conservative defaults
+            proxy_buffer_size       16k;   # default: 4k|8k (one memory page)
+            proxy_buffers           4 16k; # default: 8 4k|8k
+            proxy_busy_buffers_size 16k;   # default: 8k|16k (two memory pages)
         }
     }
 }


### PR DESCRIPTION
OK so nginx has extremely conservative defaults for the memory it pre-allocates to read upstream HTTP header responses, for example our app responding with a `Set-Cookie` header.

We haven't run in to this yet just because, our home rolled and tight auth has always come in under the default. Now using better-auth it seems like more data is being written which means nginx needs to increase the amount of memory it pre-allocates for the response headers.

To put this in to perspective, the difference for 10,000 _concurrent_ connections would be 160mb memory used up from 40mb.. so the impact for us is negligible.

This change is also entirely backwards compatible