### PR TITLE
Allow request bodies of 50mb

### DIFF
--- a/nginx/ssl-termination/nginx.conf
+++ b/nginx/ssl-termination/nginx.conf
@@ -6,6 +6,9 @@ http {
         ssl_certificate     /app/ssl/server.crt;
         ssl_certificate_key /app/ssl/server.key;
 
+        # Allow larger request bodies than nginx's 1m default (e.g. file uploads)
+        client_max_body_size 50m;
+
         location / {
             proxy_pass       http://127.0.0.1:2300;
             proxy_set_header Host $host;

--- a/nginx/ssl-termination/nginx.conf
+++ b/nginx/ssl-termination/nginx.conf
@@ -14,6 +14,11 @@ http {
             proxy_set_header Host $host;
             port_in_redirect off;
 
+            # Long-running requests (e.g. LLM report generation) can be silent for
+            # up to 255s (Bun's max idle timeout). Sit above that so the app, not
+            # nginx (60s default), is what decides a connection is dead.
+            proxy_read_timeout 300s;
+
             # Upstream can write larger response headers than nginx's extremely conservative defaults
             proxy_buffer_size       16k;   # default: 4k|8k (one memory page)
             proxy_buffers           4 16k; # default: 8 4k|8k


### PR DESCRIPTION
No need to merge this, just showing you the diff. I've pushed this to the `high-buffer` tag